### PR TITLE
Handle multiple chevrons (fixes #1)

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -192,8 +192,10 @@ bool tree_sitter_pod_external_scanner_scan(
         ADVANCE_C;
         count--;
       }
-      chevron_count_pop(state);
-      TOKEN(TOKEN_INTSEQ_END);
+      if(!count) {
+        chevron_count_pop(state);
+        TOKEN(TOKEN_INTSEQ_END);
+      }
     }
 
     if(c >= 'A' && c <= 'Z') {

--- a/test/corpus/interior-sequences
+++ b/test/corpus/interior-sequences
@@ -47,6 +47,18 @@ B<I<bold italic>>
         (content
           (interior_sequence (sequence_letter) (content)))))))
 ==========
+Multiple nested
+==========
+A<< contains <=> and B<b> inside it >>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (interior_sequence
+        (sequence_letter)
+        (content
+          (interior_sequence (sequence_letter) (content)))))))
+==========
 Unconfused by single letters
 ==========
 B

--- a/test/corpus/interior-sequences
+++ b/test/corpus/interior-sequences
@@ -59,6 +59,18 @@ A<< contains <=> and B<b> inside it >>
         (content
           (interior_sequence (sequence_letter) (content)))))))
 ==========
+Does not consume shorter sequence of '>'
+==========
+C<<> still inside C here; so A<is inside both>>>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (interior_sequence
+        (sequence_letter)
+        (content
+          (interior_sequence (sequence_letter) (content)))))))
+==========
 Unconfused by single letters
 ==========
 B

--- a/test/corpus/interior-sequences
+++ b/test/corpus/interior-sequences
@@ -26,6 +26,15 @@ normal B<bold> content
     (content
       (interior_sequence (sequence_letter) (content)))))
 ==========
+Multiple chevrons
+==========
+A sequence with C<< inner->arrows >>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (interior_sequence (sequence_letter) (content)))))
+==========
 Nested sequence
 ==========
 B<I<bold italic>>


### PR DESCRIPTION
Better support for multiple sets of brackets on interior sequences
    
Count opening brackets for an interior sequence; require the same number to close, shorter sequences are ignored.
    
Handle nested chevron counts of differing numbers in a (small) stack, allowing up to 8 levels.

I've so far been unable to write a unit-test file for this because the "corpus"-style tests aren't sensitive to match positions, and we aren't able to write "highlight"-style tests as we don't have a comment node.