### PR TITLE
Also highlight U<...> as @text.underline

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -32,6 +32,10 @@
   (content) @text.literal)
 (interior_sequence
   (sequence_letter) @character
+  (#eq? @character "U")
+  (content) @text.underline)
+(interior_sequence
+  (sequence_letter) @character
   (#eq? @character "F")
   (content) @text.underline @string.special)
 (interior_sequence


### PR DESCRIPTION
Still currently just a proposed addition to Pod; see also https://github.com/Perl/perl5/pull/21509

Not necessarily ready to merge *yet* until the core spec is accepted, but this seems an easy enough change to make if that happens.