### PR TITLE
feat: parse E<...> as a distinct escape_sequence node

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - uses: tree-sitter/setup-action/cli@v2
       - run: tree-sitter generate src/grammar.json

--- a/grammar.js
+++ b/grammar.js
@@ -10,6 +10,7 @@ module.exports = grammar({
     $._intseq_start,
     $._intseq_end,
     $._data_section,
+    $._intseq_escape_letter,
   ],
   rules: {
     pod: $ => repeat(choice(
@@ -62,7 +63,7 @@ module.exports = grammar({
     cut_command: $ => '=cut',
 
     content: $ => $._content,
-    _content: $ => repeat1(choice($._content_plain, $.interior_sequence)),
+    _content: $ => repeat1(choice($._content_plain, $.interior_sequence, $.escape_sequence)),
 
     interior_sequence: $ => seq(
       field('letter', $.sequence_letter),
@@ -71,5 +72,18 @@ module.exports = grammar({
       alias($._intseq_end, '>'),
     ),
     sequence_letter: $ => $._intseq_letter,
+
+    // E<...> is always an escape sequence; its content is an entity name or
+    // number (e.g. lt, gt, copy, 0x263A), not nested Pod markup. The content
+    // is a repeat1 of plain tokens (rather than a single one) so that the
+    // scanner always sees TOKEN_CONTENT_PLAIN co-valid with TOKEN_INTSEQ_END,
+    // which is the condition under which it will emit the closing '>'.
+    escape_sequence: $ => seq(
+      field('letter', alias($._intseq_escape_letter, $.sequence_letter)),
+      alias($._intseq_start, '<'),
+      optional(alias($._escape_content, $.content)),
+      alias($._intseq_end, '>'),
+    ),
+    _escape_content: $ => repeat1($._content_plain),
   },
 })

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -73,7 +73,7 @@
   (#eq? @character "X")
   (content) @text.reference)
 
-(interior_sequence
+(escape_sequence
   (sequence_letter) @character
-  (#eq? @character "E")
+  ["<" ">"] @punctuation.delimiter
   (content) @string.escape)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -316,6 +316,10 @@
           {
             "type": "SYMBOL",
             "name": "interior_sequence"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "escape_sequence"
           }
         ]
       }
@@ -366,6 +370,66 @@
     "sequence_letter": {
       "type": "SYMBOL",
       "name": "_intseq_letter"
+    },
+    "escape_sequence": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "letter",
+          "content": {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_intseq_escape_letter"
+            },
+            "named": true,
+            "value": "sequence_letter"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intseq_start"
+          },
+          "named": false,
+          "value": "<"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_escape_content"
+              },
+              "named": true,
+              "value": "content"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_intseq_end"
+          },
+          "named": false,
+          "value": ">"
+        }
+      ]
+    },
+    "_escape_content": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_content_plain"
+      }
     }
   },
   "extras": [
@@ -412,6 +476,10 @@
     {
       "type": "SYMBOL",
       "name": "_data_section"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_intseq_escape_letter"
     }
   ],
   "inline": [],

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -45,6 +45,7 @@ enum TokenType {
   TOKEN_INTSEQ_START,
   TOKEN_INTSEQ_END,
   TOKEN_DATA_SECTION,
+  TOKEN_INTSEQ_ESCAPE_LETTER,
 };
 
 #define MAX_NESTED_CHEVRONS 8
@@ -279,11 +280,16 @@ bool tree_sitter_pod_external_scanner_scan(
     }
 
     if(c >= 'A' && c <= 'Z') {
+      int letter = c;
       ADVANCE_C;
       got_plain = true;
 
       /* don't read these in a verbatim paragraph */
       if(c == '<' && valid_symbols[TOKEN_INTSEQ_LETTER]) {
+        /* E<...> is an escape sequence, not generic markup; its content is
+         * an entity name or number, so emit a distinct letter token. */
+        if(letter == 'E' && valid_symbols[TOKEN_INTSEQ_ESCAPE_LETTER])
+          TOKEN(TOKEN_INTSEQ_ESCAPE_LETTER);
         TOKEN(TOKEN_INTSEQ_LETTER);
       }
     }

--- a/test/corpus/interior-sequences
+++ b/test/corpus/interior-sequences
@@ -104,3 +104,60 @@ Z<
 (pod
   (ERROR (sequence_letter) (cut_command))
 )
+==========
+Escape sequence
+==========
+E<lt>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (escape_sequence (sequence_letter) (content)))))
+==========
+Empty escape sequence
+==========
+E<>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (escape_sequence (sequence_letter)))))
+==========
+Numeric escape sequence
+==========
+E<0x263A>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (escape_sequence (sequence_letter) (content)))))
+==========
+Escape with multiple chevrons
+==========
+E<< verbar >>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (escape_sequence (sequence_letter) (content)))))
+==========
+Escape content is not markup
+==========
+E<B<lt>>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (escape_sequence (sequence_letter) (content)))))
+==========
+Escape nested in other sequence
+==========
+B<some E<gt> thing>
+----------
+(pod
+  (plain_paragraph
+    (content
+      (interior_sequence
+        (sequence_letter)
+        (content
+          (escape_sequence (sequence_letter) (content)))))))


### PR DESCRIPTION
## Summary

`E<...>` is always a Pod escape sequence whose content is an entity name or number (`lt`, `gt`, `copy`, `0x263A`, ...), **not** nested Pod markup. Previously it parsed as a generic `interior_sequence` with markup content inside — so `E<B<lt>>` would (incorrectly) treat `B<lt>` as bold markup.

This adds a dedicated `escape_sequence` node:

- **`src/scanner.c`** — emits a distinct `_intseq_escape_letter` token when the sequence letter is `E`.
- **`grammar.js`** — new `escape_sequence` rule whose content is plain text only (`repeat1` of `_content_plain`, so `CONTENT_PLAIN` stays co-valid with `INTSEQ_END` — the condition the scanner requires to emit the closing `>`).
- **`queries/highlights.scm`** — retargets the `E` → `@string.escape` rule from `interior_sequence` to `escape_sequence`, and highlights its delimiters/letter.
- **CI** — bumps the npm publish job to Node 24.

`Z<>` and `L<>` continue to parse as generic interior sequences; nesting like `B<E<gt> bold>` works.

## Tests

6 new corpus cases (basic, empty `E<>`, numeric `E<0x263A>`, multi-chevron `E<< … >>`, content-is-not-markup, nested inside `B<…>`). All 29 corpus tests pass.

## Note for maintainers

The scanner only emits the closing `>` (`TOKEN_INTSEQ_END`) from *inside* the `if(valid_symbols[TOKEN_CONTENT_PLAIN])` block, so any sequence content rule must keep `CONTENT_PLAIN` co-valid with `INTSEQ_END`. That's why escape content is `repeat1(_content_plain)` rather than a single optional token. Future structured-sequence work (e.g. `L<>` links) will need the same care or a refactor of that block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)